### PR TITLE
Add Satellite support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,14 @@ Available variables are listed below, along with default values (see `defaults/m
 
 ```yml
 epel_repo_file: "/etc/yum.repos.d/epel.repo"
-epel_repo_url: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
-epel_gpg_url: "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
+epel_repo_url: "https://dl.fedoraproject.org/pub/epel/$releasever/$basearch/"
+epel_gpg_file: "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
+epel_gpg_url: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
+epel_gpg_check: "yes"
+
+epel_satellite: false #change to true when you want to get EPEL packages from an internal Satellite mirror
+epel_satellite_label: "" #when epel_satellite is true:  add repo with subscription-manager
+                         #                       false: remove repo with subscription-manager
 ```
 
 ## Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,3 +4,6 @@ epel_repo_url: "https://dl.fedoraproject.org/pub/epel/$releasever/$basearch/"
 epel_gpg_file: "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
 epel_gpg_url: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
 epel_gpg_check: "yes"
+
+epel_satellite: false #change to true when you want to get EPEL packages from an internal Satellite mirror
+epel_satellite_label: ""

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,45 @@
 ---
-- name: install EPEL repository
-  yum_repository:
-    name: epel
-    state: present
-    description: EPEL YUM repo
-    baseurl: "{{ epel_repo_url }}"
-    gpgkey: "{{ epel_gpg_url }}"
-    gpgcheck: "{{ epel_gpg_check }}"
-  notify:
-    - update cache
+- name: determine if subscription-manager exists
+  stat:
+    path: "/usr/sbin/subscription-manager"
+  register: sm
+
+- block:
+  - name: ensure EPEL repository from Satellite is absent
+    rhsm_repository:
+      name: "{{ epel_satellite_label }}"
+      state: absent
+    when: epel_satellite_label != "" and sm.stat.exists
+
+  - name: install external EPEL repository
+    yum_repository:
+      name: epel
+      state: present
+      description: EPEL YUM repo
+      baseurl: "{{ epel_repo_url }}"
+      gpgkey: "{{ epel_gpg_url }}"
+      gpgcheck: "{{ epel_gpg_check }}"
+    notify:
+      - update cache
+  when: not epel_satellite
+
+- block:
+  - fail:
+      msg: "The var epel_satellite_label is not set"
+    when: epel_satellite_label == ""
+
+  - name: ensure external EPEL repository config is absent
+    yum_repository:
+      name: epel
+      state: absent
+
+  - name: ensure external EPEL repository package is absent
+    package:
+      name: epel-release
+      state: absent
+
+  - name: install EPEL repository from Satellite
+    rhsm_repository:
+      name: "{{ epel_satellite_label }}"
+      state: present
+  when: epel_satellite


### PR DESCRIPTION
This change enables you to add EPEL from a previously registered
Satellite subscription, and also enable you to reverse it to the normal
direct EPEL if needed.