### PR TITLE
fix: deprecated state value

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,5 +42,5 @@
   - name: install EPEL repository from Satellite
     rhsm_repository:
       name: "{{ epel_satellite_label }}"
-      state: present
+      state: enabled
   when: epel_satellite


### PR DESCRIPTION
## Description
a partir da versão 10.0 do ansible (lançada há um ano), valor de state mudou de present pra enabled.
https://docs.ansible.com/ansible/latest/collections/community/general/rhsm_repository_module.html#parameter-state

essa é a linha que quebra na role:
https://github.com/stone-payments/ansible-epel/blob/60972dbd87e0fc2432bec94d6c60768ed4a59f22/tasks/main.yml#L45

_essa mudança pode ser uma breaking change para clientes que ainda utilizam ansible em versões inferiores à 10.0._

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)